### PR TITLE
authorized/unauthorized dbs and routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ samaritan-backend.iml
 venv/*
 .DS_Store
 __pycache__/
+.vscode
 
 images/unknown

--- a/app.py
+++ b/app.py
@@ -228,6 +228,7 @@ def get_all_authorized():
     response.headers.add('Access-Control-Allow-Origin', '*')
     return response
 
+
 """
 returns all unauthorized user ref-ids
 (ref_id refers to the user's id in known or unknown)
@@ -242,6 +243,19 @@ def get_all_unauthorized():
     response = jsonify(entries)
     response.headers.add('Access-Control-Allow-Origin', '*')
     return response
+
+
+"""
+"""
+@app.route('/unauthorized/<ref_id>', methods=['GET'])
+def check_for_unauthorized(ref_id : str):
+    result = db.unauthorized.find({"ref_id": ref_id})
+    result_count = result.count()
+    if result_count < 1:
+        response = False
+    else:
+        response = True
+    return json.dumps(response)
 
 """
 route to delete all known and unknown until we 

--- a/app.py
+++ b/app.py
@@ -8,8 +8,7 @@ from bson.objectid import ObjectId
 from mongoengine import connect
 
 app = Flask(__name__)
-client: MongoClient = MongoClient(
-    "localhost:27017")
+client: MongoClient = MongoClient("localhost:27017")
 
 db = client.user  # need for non graphql routes that access db
 
@@ -189,41 +188,41 @@ def get_all_unknown():
 """
 adds to authorized
 """
-@app.route('/authorized', methods=[POST])
+@app.route('/authorized', methods=['POST'])
 def add_authorized():
     data = request.get_json("data")
-    _id = data["_id"]
+    ref_id = data["ref_id"]
     authorized = {
-        "ref_id": _id
+        "ref_id": ref_id
     }
     result = db.authorized.insert_one(authorized)
-    return make_response(result)
+    return make_response()
 
 
 """
 adds to unauthorized
 """
-@app.route('/unauthorized', methods=[POST])
+@app.route('/unauthorized', methods=['POST'])
 def add_unauthorized():
     data = request.get_json("data")
-    _id = data["_id"]
+    ref_id = data["ref_id"]
     unauthorized = {
-        "ref_id": _id
+        "ref_id": ref_id
     }
     result = db.unauthorized.insert_one(unauthorized)
-    return make_response(result)
+    return make_response()
 
 
 """
 returns all authorized user ref_ids
 (reF_id referes to the user's id in known or unknown)
 """
-@app.route('/authorized', methods=[GET])
+@app.route('/authorized', methods=['GET'])
 def get_all_authorized():
     entries = []
     cursor = db.authorized.find({})
     for document in cursor:
-        document["_id"] = str(document["id"])
+        document["_id"] = str(document["_id"])
         entries.append(document)
     response = jsonify(entries)
     response.headers.add('Access-Control-Allow-Origin', '*')
@@ -233,7 +232,7 @@ def get_all_authorized():
 returns all unauthorized user ref-ids
 (ref_id refers to the user's id in known or unknown)
 """
-@app.route('/unauthorized', methods=[GET])
+@app.route('/unauthorized', methods=['GET'])
 def get_all_unauthorized():
     entries = []
     cursor = db.unauthorized.find({})
@@ -254,6 +253,8 @@ TODO: remove this when stuff is good
 def delete_all_known_unknown():
     db.unknown.remove({})
     db.known.remove({})
+    db.authorized.remove({})
+    db.unauthorized.remove({})
 
     return make_response()
 

--- a/app.py
+++ b/app.py
@@ -187,6 +187,64 @@ def get_all_unknown():
 
 
 """
+adds to authorized
+"""
+@app.route('/authorized', methods=[POST])
+def add_authorized():
+    data = request.get_json("data")
+    _id = data["_id"]
+    authorized = {
+        "ref_id": _id
+    }
+    result = db.authorized.insert_one(authorized)
+    return make_response(result)
+
+
+"""
+adds to unauthorized
+"""
+@app.route('/unauthorized', methods=[POST])
+def add_unauthorized():
+    data = request.get_json("data")
+    _id = data["_id"]
+    unauthorized = {
+        "ref_id": _id
+    }
+    result = db.unauthorized.insert_one(unauthorized)
+    return make_response(result)
+
+
+"""
+returns all authorized user ref_ids
+(reF_id referes to the user's id in known or unknown)
+"""
+@app.route('/authorized', methods=[GET])
+def get_all_authorized():
+    entries = []
+    cursor = db.authorized.find({})
+    for document in cursor:
+        document["_id"] = str(document["id"])
+        entries.append(document)
+    response = jsonify(entries)
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    return response
+
+"""
+returns all unauthorized user ref-ids
+(ref_id refers to the user's id in known or unknown)
+"""
+@app.route('/unauthorized', methods=[GET])
+def get_all_unauthorized():
+    entries = []
+    cursor = db.unauthorized.find({})
+    for document in cursor:
+        document["_id"] = str(document["_id"])
+        entries.append(document)
+    response = jsonify(entries)
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    return response
+
+"""
 route to delete all known and unknown until we 
 figure it out
 

--- a/app.py
+++ b/app.py
@@ -246,6 +246,8 @@ def get_all_unauthorized():
 
 
 """
+checks if a ref_id exists in the unauthorized db.
+returns True if exists, False otherwise
 """
 @app.route('/unauthorized/<ref_id>', methods=['GET'])
 def check_for_unauthorized(ref_id : str):
@@ -256,6 +258,28 @@ def check_for_unauthorized(ref_id : str):
     else:
         response = True
     return json.dumps(response)
+
+
+"""
+removes ref_id from authorized db
+"""
+@app.route('/authorized/<ref_id>', methods=['DELETE'])
+def remove_from_authorized(ref_id : str):
+    result = db.authorized.remove({"ref_id" : ref_id})
+    response = jsonify(result)
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    return response
+
+"""
+removed given ref_id from unauthorized db
+"""
+@app.route('/unauthorized/<ref_id>', methods=['DELETE'])
+def remove_from_unauthorized(ref_id : str):
+    result = db.unauthorized.remove({"ref_id" : ref_id})
+    response = jsonify(result)
+    response.headers.add('Acess-Control-Allow-Origin', '*')
+    return response
+
 
 """
 route to delete all known and unknown until we 

--- a/app.py
+++ b/app.py
@@ -187,30 +187,50 @@ def get_all_unknown():
 
 """
 adds to authorized
+returns 200 if added, 500 if duplicate id
 """
 @app.route('/authorized', methods=['POST'])
 def add_authorized():
     data = request.get_json("data")
     ref_id = data["ref_id"]
     authorized = {
-        "ref_id": ref_id
+        "_id": ref_id
     }
-    result = db.authorized.insert_one(authorized)
-    return make_response()
+    try:
+        result = db.authorized.insert_one(authorized)
+    except:
+        return app.response_class(
+            status=500,
+            mimetype='application/json'
+        )
+    return app.response_class(
+        status=200,
+        mimetype='application/json'
+    )
 
 
 """
 adds to unauthorized
+returns 200 if added, 500 if duplicate id
 """
 @app.route('/unauthorized', methods=['POST'])
 def add_unauthorized():
     data = request.get_json("data")
     ref_id = data["ref_id"]
     unauthorized = {
-        "ref_id": ref_id
+        "_id": ref_id
     }
-    result = db.unauthorized.insert_one(unauthorized)
-    return make_response()
+    try:
+        result = db.unauthorized.insert_one(unauthorized)
+    except:
+        return app.response_class(
+            status=500,
+            mimetype='application/json'
+        )
+    return app.response_class(
+        status=200,
+        mimetype='application/json'
+    )
 
 
 """
@@ -251,13 +271,17 @@ returns True if exists, False otherwise
 """
 @app.route('/unauthorized/<ref_id>', methods=['GET'])
 def check_for_unauthorized(ref_id : str):
-    result = db.unauthorized.find({"ref_id": ref_id})
+    result = db.unauthorized.find({"_id": ref_id})
     result_count = result.count()
     if result_count < 1:
         response = False
     else:
         response = True
-    return json.dumps(response)
+    return app.response_class(
+        response=json.dumps(response),
+        status=200,
+        mimetype='application/json'
+    )
 
 
 """
@@ -269,6 +293,7 @@ def remove_from_authorized(ref_id : str):
     response = jsonify(result)
     response.headers.add('Access-Control-Allow-Origin', '*')
     return response
+
 
 """
 removed given ref_id from unauthorized db


### PR DESCRIPTION
added some routes for db access for authorized and unauthorized:
- /authorized [POST], takes `{"ref_id": str}` and adds to authorized 
- /authorized [GET], returns all authorized ids
- /authorized/<ref_id> [DELETE], removes ref_id from db
- /unauthorized [POST], takes `{"ref_id":str}` and adds to unauthorized
- /unauthorized [GET], returns all unauthorized ids
- /unauthorized/<ref_id> [DELETE], removes ref_id from db
- /unauthorized/<ref_id> [GET], returns True if id in unauthorized, false otherwise

The authorized and unauthorized db's store _id, which is a reference to a user's _id in known or unknown db's. 

Frontend will use the first six routes for action requests, the Alerts module will use the last route.