### PR TITLE
multi camera db and route support

### DIFF
--- a/FacialRecog.py
+++ b/FacialRecog.py
@@ -16,7 +16,7 @@ import cv2
 import os
 import numpy as np
 
-from app import add_known_person, add_unknown_person, get_all_people
+from app import add_known_person, add_unknown_person, get_all_people, get_all_cameras
 
 
 def get_video_from_file(filename: str):
@@ -143,3 +143,11 @@ def compare_encodings(frame_encodings, all_encodings):
         encodings.append(face_recognition.compare_faces(face, frame_encodings))
 
     return encodings
+
+
+"""
+returns a list of all cameras in db
+"""
+def all_cameras():
+    cameras = get_all_cameras("not_api_call")
+    return cameras

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -5,7 +5,7 @@ import base64
 import face_recognition
 import datetime
 
-from app import app
+from app import app, add_new_alert, add_new_seen
 from FacialRecog import *
 
 
@@ -62,9 +62,8 @@ class APITest(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_add_new_seen(self):
-        route = "/seen/5e545bcbd541d79f9ef5b0c7"
-        result = self.app.put(route)
-        self.assertEqual(result.status_code, 200)
+        result = add_new_seen("5e545bcbd541d79f9ef5b0c7")
+        self.assertEqual(result.acknowledged, True)
 
     def test_get_all_seen(self):
         result = self.app.get("/seen")
@@ -109,13 +108,26 @@ class APITest(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_add_new_alert(self):
-        route = "/alerts/5e545bcbd541d79f9ef5b0c7"
-        result = self.app.put(route)
-        self.assertEqual(result.status_code, 200)
+        result = add_new_alert("5e545bcbd541d79f9ef5b0c7")
+        self.assertEqual(result.acknowledged, True)
 
     def test_get_all_alerts(self):
         result = self.app.get("/alerts")
         self.assertEqual(result.status_code, 200)
 
+    def test_add_new_camera(self):
+        data = {"ip" : "192.168.1.107", "nickname" : "home-camera"}
+        result = self.app.post("/camera", data=json.dumps(data), content_type="application/json")
+        self.assertEqual(result.status_code, 200)
+
+    def test_get_camera_by_id(self):
+        route = "/camera/5e795368354d37c78043626e"
+        result = self.app.get(route)
+        self.assertEqual(result.status_code, 200)
+
+    def test_get_all_cameras(self):
+        route = "/camera"
+        result = self.app.get(route)
+        self.assertEquals(result.status_code, 200)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/facial_recog_tests.py
+++ b/tests/facial_recog_tests.py
@@ -106,5 +106,13 @@ class ScriptTest(unittest.TestCase):
 
         self.assertEqual(i == 2, True)
 
+    
+    """
+    tests that function returns list of cameras with ip & nickname
+    """
+    def test_all_cameras(self):
+        cameras = all_cameras()
+        self.assertEqual(len(cameras) > 0 and len(cameras[0]['ip']) > 0 and len(cameras[0]['nickname']) > 0 , True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- added 'cameras' db
- added a few routes
  - /camera [POST] -> adds a new camera, given ip and nickname
  - /camera/<camera_id> [GET] -> given id, returns camera
  - /camera [GET] -> returns all cameras

added tests for these routes in api_tests.py
- test_add_new_camera
- test_get_camera_by_id
- test_get_all_cameras

also, while initially running api_tests.py it failed because of 
- test_add_new_alert
- test_add_new_seen
this was because of an ad hoc change we made before, so i switched the functions add_new_seen and add_new_alert to not return a http response, but just the data response, because they are only accessed by the backend anyways (aka they don't need a route), and i updated the tests for them to reflect that change. 

closes #60, closes #61 ,closes #62 